### PR TITLE
Chore: Ignore local guideline docs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 /CONTRIBUTING.md
+/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+/CONTRIBUTING.md


### PR DESCRIPTION
Summary
- Adds CONTRIBUTING.md to .gitignore so it stays local instead of being tracked/pushed.
- Adds CLAUDE.md to .gitignore for the same reason.

Why
- These are local reference/guideline docs not meant to be part of the tracked repo history.